### PR TITLE
fix(DocsThemer): fix quote problem with serif/mono fonts

### DIFF
--- a/sites/skeleton.dev/src/lib/layouts/DocsThemer/settings.ts
+++ b/sites/skeleton.dev/src/lib/layouts/DocsThemer/settings.ts
@@ -35,9 +35,9 @@ export const fontSettings: Record<string, string> = {
 	// Tailwind Sans-Serif
 	sans: `Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'`,
 	// Tailwind Serif
-	serif: `ui-serif, Georgia, Cambria, "Times New Roman", Times, serif`,
+	serif: `ui-serif, Georgia, Cambria, 'Times New Roman', Times, serif`,
 	// Tailwind Mono
-	mono: `ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace`,
+	mono: `ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', "Courier New", monospace`,
 	// System UI
 	system: `system-ui`
 };


### PR DESCRIPTION
## Description

Quick fix for quotation marks in the theme generator for the CSS-in-JS format.

![image](https://github.com/leranjun/skeleton/assets/25704248/a0e237c8-e5c9-4f0d-9594-0f688e69d70b)

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages/skeleton`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
